### PR TITLE
fix(ethereum): prevent BAD_DATA error when fetching ERC20 balance

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "zustand": "^4.4.1"
   },
   "devDependencies": {
+    "@types/jsdom": "^21.1.7",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
@@ -58,6 +59,7 @@
     "autoprefixer": "^10.4.17",
     "eslint": "^9.25.0",
     "eslint-config-next": "15.2.4",
+    "jsdom": "^27.0.1",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5",

--- a/src/services/ethereum/balance.test.ts
+++ b/src/services/ethereum/balance.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getERC20Balance } from "./balance";
+
+// Mock ethers module
+vi.mock("ethers", () => ({
+  BrowserProvider: vi.fn(),
+  Contract: vi.fn(),
+  formatUnits: vi.fn(),
+}));
+
+// Mock the contract utility
+vi.mock("./contract", () => ({
+  isContractDeployed: vi.fn(),
+}));
+
+// Mock the abis module
+vi.mock("./abis", () => ({
+  ERC20_ABI: [],
+}));
+
+describe("getERC20Balance", () => {
+  const mockTokenAddress = "0x327d741E500E11Ab69F9D1A496A0ab4F934fA463";
+  const mockWalletAddress = "0x1234567890123456789012345678901234567890";
+  const mockDecimals = 6;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock window.ethereum using vi.stubGlobal
+    vi.stubGlobal("ethereum", {});
+  });
+
+  afterEach(() => {
+    // Restore all stubbed globals
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null when no ethereum provider is available", async () => {
+    // Remove ethereum provider
+    vi.stubGlobal("ethereum", undefined);
+
+    const result = await getERC20Balance(mockTokenAddress, mockWalletAddress, mockDecimals);
+
+    expect(result.balance).toBeNull();
+    expect(result.error).toBe("No ethereum provider");
+  });
+
+  it("returns null when no contract exists at address", async () => {
+    const { isContractDeployed } = await import("./contract");
+    vi.mocked(isContractDeployed).mockResolvedValue(false);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await getERC20Balance(mockTokenAddress, mockWalletAddress, mockDecimals);
+
+    expect(isContractDeployed).toHaveBeenCalledWith(mockTokenAddress);
+    expect(result.balance).toBeNull();
+    expect(result.error).toBe("Contract does not exist");
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("No contract deployed"));
+
+    warnSpy.mockRestore();
+  });
+
+  it("fetches balance successfully when contract exists", async () => {
+    const { isContractDeployed } = await import("./contract");
+    const { BrowserProvider, Contract, formatUnits } = await import("ethers");
+
+    vi.mocked(isContractDeployed).mockResolvedValue(true);
+
+    const mockBalanceOf = vi.fn().mockResolvedValue(BigInt("1000000")); // 1 USDC
+    const mockProvider = {};
+    const mockContract = { balanceOf: mockBalanceOf };
+
+    vi.mocked(BrowserProvider).mockImplementation(
+      () => mockProvider as unknown as InstanceType<typeof BrowserProvider>
+    );
+    vi.mocked(Contract).mockImplementation(
+      () => mockContract as unknown as InstanceType<typeof Contract>
+    );
+    vi.mocked(formatUnits).mockReturnValue("1.0");
+
+    const result = await getERC20Balance(mockTokenAddress, mockWalletAddress, mockDecimals);
+
+    expect(isContractDeployed).toHaveBeenCalledWith(mockTokenAddress);
+    expect(mockBalanceOf).toHaveBeenCalledWith(mockWalletAddress);
+    expect(result.balance).toBe("1.0");
+    expect(result.error).toBeNull();
+  });
+
+  it("handles BAD_DATA error gracefully", async () => {
+    const { isContractDeployed } = await import("./contract");
+    const { BrowserProvider, Contract } = await import("ethers");
+
+    vi.mocked(isContractDeployed).mockResolvedValue(true);
+
+    const mockBalanceOf = vi.fn().mockRejectedValue(
+      new Error('could not decode result data (value="0x", code=BAD_DATA)')
+    );
+    const mockProvider = {};
+    const mockContract = { balanceOf: mockBalanceOf };
+
+    vi.mocked(BrowserProvider).mockImplementation(
+      () => mockProvider as unknown as InstanceType<typeof BrowserProvider>
+    );
+    vi.mocked(Contract).mockImplementation(
+      () => mockContract as unknown as InstanceType<typeof Contract>
+    );
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await getERC20Balance(mockTokenAddress, mockWalletAddress, mockDecimals);
+
+    expect(result.balance).toBeNull();
+    expect(result.error).toBe("Contract does not implement balanceOf");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("may not implement balanceOf")
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("handles generic errors gracefully", async () => {
+    const { isContractDeployed } = await import("./contract");
+    const { BrowserProvider, Contract } = await import("ethers");
+
+    vi.mocked(isContractDeployed).mockResolvedValue(true);
+
+    const mockBalanceOf = vi.fn().mockRejectedValue(new Error("Network error"));
+    const mockProvider = {};
+    const mockContract = { balanceOf: mockBalanceOf };
+
+    vi.mocked(BrowserProvider).mockImplementation(
+      () => mockProvider as unknown as InstanceType<typeof BrowserProvider>
+    );
+    vi.mocked(Contract).mockImplementation(
+      () => mockContract as unknown as InstanceType<typeof Contract>
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await getERC20Balance(mockTokenAddress, mockWalletAddress, mockDecimals);
+
+    expect(result.balance).toBeNull();
+    expect(result.error).toBe("Network error");
+    expect(errorSpy).toHaveBeenCalledWith("Error fetching balance:", expect.any(Error));
+
+    errorSpy.mockRestore();
+  });
+});

--- a/src/services/ethereum/balance.ts
+++ b/src/services/ethereum/balance.ts
@@ -1,0 +1,55 @@
+// src/services/ethereum/balance.ts
+import { ERC20_ABI } from "./abis";
+import { isContractDeployed } from "./contract";
+
+/**
+ * Represents the result of a balance fetching operation.
+ *
+ * This interface is used to encapsulate the result of retrieving a balance,
+ * including the balance itself and any error message that may occur during the operation.
+ *
+ * Properties:
+ * - `balance`: A string representing the fetched balance, or null if unavailable.
+ * - `error`: A string describing any error encountered during the fetch, or null if no errors occurred.
+ */
+export interface BalanceFetchResult {
+  balance: string | null;
+  error: string | null;
+}
+
+/**
+ * Fetches the ERC20 token balance for a given wallet address.
+ *
+ * @param {string} tokenAddress - The contract address of the ERC20 token.
+ * @param {string} walletAddress - The address of the wallet for which the balance is being retrieved.
+ * @param {number} decimals - The number of decimals used by the token for formatting its balance.
+ * @return {Promise<BalanceFetchResult>} A promise that resolves to an object containing the balance or an error message.
+ */
+export async function getERC20Balance(tokenAddress: string, walletAddress: string, decimals: number): Promise<BalanceFetchResult> {
+  if (typeof window === "undefined" || !window.ethereum) return { balance: null, error: "No ethereum provider" };
+
+  try {
+    // Check if the contract exists first
+    const contractExists = await isContractDeployed(tokenAddress);
+    if (!contractExists) {
+      console.warn(`No contract deployed at ${tokenAddress} on current network`);
+      return { balance: null, error: "Contract does not exist" };
+    }
+
+    const { BrowserProvider, Contract, formatUnits } = await import("ethers");
+    const browserProvider = new BrowserProvider(window.ethereum);
+    const tokenContract = new Contract(tokenAddress, ERC20_ABI, browserProvider)
+    const balance = await tokenContract.balanceOf(walletAddress);
+    const balanceFormatted = formatUnits(balance, decimals);
+
+    return { balance: balanceFormatted, error: null };
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("BAD_DATA")) {
+      console.warn(`Contract at ${tokenAddress} may not implement balanceOf or is not an ERC20 token`);
+      return { balance: null, error: "Contract does not implement balanceOf" };
+    }
+    console.error("Error fetching balance:", err);
+    return { balance: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+
+}

--- a/src/services/ethereum/contract.test.ts
+++ b/src/services/ethereum/contract.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { isContractDeployed } from "./contract";
+
+// Mock ethers module
+vi.mock("ethers", () => ({
+  BrowserProvider: vi.fn(),
+}));
+
+describe("isContractDeployed", () => {
+  const mockAddress = "0x327d741E500E11Ab69F9D1A496A0ab4F934fA463";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock window.ethereum using vi.stubGlobal
+    vi.stubGlobal("ethereum", {});
+  });
+
+  afterEach(() => {
+    // Restore all stubbed globals
+    vi.unstubAllGlobals();
+  });
+
+  it("returns false when no ethereum provider is available", async () => {
+    // Remove ethereum provider
+    vi.stubGlobal("ethereum", undefined);
+
+    const result = await isContractDeployed(mockAddress);
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when getCode returns 0x (no contract)", async () => {
+    const { BrowserProvider } = await import("ethers");
+    const mockGetCode = vi.fn().mockResolvedValue("0x");
+    const mockProvider = { getCode: mockGetCode };
+
+    vi.mocked(BrowserProvider).mockImplementation(
+      () => mockProvider as unknown as InstanceType<typeof BrowserProvider>
+    );
+
+    const result = await isContractDeployed(mockAddress);
+
+    expect(mockGetCode).toHaveBeenCalledWith(mockAddress);
+    expect(result).toBe(false);
+  });
+
+  it("returns true when getCode returns bytecode (contract exists)", async () => {
+    const { BrowserProvider } = await import("ethers");
+    const mockGetCode = vi
+      .fn()
+      .mockResolvedValue("0x608060405234801561001057600080fd5b50");
+    const mockProvider = { getCode: mockGetCode };
+
+    vi.mocked(BrowserProvider).mockImplementation(
+      () => mockProvider as unknown as InstanceType<typeof BrowserProvider>
+    );
+
+    const result = await isContractDeployed(mockAddress);
+
+    expect(mockGetCode).toHaveBeenCalledWith(mockAddress);
+    expect(result).toBe(true);
+  });
+
+  it("returns false when getCode throws an error", async () => {
+    const { BrowserProvider } = await import("ethers");
+    const mockGetCode = vi.fn().mockRejectedValue(new Error("RPC error"));
+    const mockProvider = { getCode: mockGetCode };
+
+    vi.mocked(BrowserProvider).mockImplementation(
+      () => mockProvider as unknown as InstanceType<typeof BrowserProvider>
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await isContractDeployed(mockAddress);
+
+    expect(result).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Error checking contract deployment:",
+      expect.any(Error)
+    );
+
+    errorSpy.mockRestore();
+  });
+});

--- a/src/services/ethereum/contract.ts
+++ b/src/services/ethereum/contract.ts
@@ -1,0 +1,22 @@
+/**
+ * Checks if a contract is deployed at the given address on the current network.
+ * Uses provider.getCode() - returns "0x" if no contract exists.
+ *
+ * @param address - The contract address to check
+ * @returns Promise<boolean> - true if contract exists, false otherwise
+ */
+export async function isContractDeployed(address: string): Promise<boolean> {
+  if (typeof window === "undefined" || !window.ethereum) {
+    return false;
+  }
+
+  try {
+    const { BrowserProvider } = await import("ethers");
+    const browserProvider = new BrowserProvider(window.ethereum);
+    const code = await browserProvider.getCode(address);
+    return code !== "0x";
+  } catch (err) {
+    console.error("Error checking contract deployment:", err);
+    return false;
+  }
+}


### PR DESCRIPTION
- Add isContractDeployed() utility in contract.ts that uses provider.getCode() to check if a contract exists at an address before interacting with it
- Update getERC20Balance() in balance.ts to check contract existence first
- Add comprehensive test coverage for both contract.ts and balance.ts
- Add jsdom as dev dependency for browser environment testing